### PR TITLE
Add pool of hashes for HMAC

### DIFF
--- a/algo_hs.go
+++ b/algo_hs.go
@@ -3,6 +3,8 @@ package jwt
 import (
 	"crypto"
 	"crypto/hmac"
+	"hash"
+	"sync"
 )
 
 // NewSignerHS returns a new HMAC-based signer.
@@ -18,6 +20,9 @@ func NewSignerHS(alg Algorithm, key []byte) (Signer, error) {
 		alg:  alg,
 		hash: hash,
 		key:  key,
+		hashPool: &sync.Pool{New: func() interface{} {
+			return hmac.New(hash.New, key)
+		}},
 	}, nil
 }
 
@@ -34,6 +39,9 @@ func NewVerifierHS(alg Algorithm, key []byte) (Verifier, error) {
 		alg:  alg,
 		hash: hash,
 		key:  key,
+		hashPool: &sync.Pool{New: func() interface{} {
+			return hmac.New(hash.New, key)
+		}},
 	}, nil
 }
 
@@ -51,9 +59,10 @@ func getHashHMAC(alg Algorithm) (crypto.Hash, error) {
 }
 
 type hsAlg struct {
-	alg  Algorithm
-	hash crypto.Hash
-	key  []byte
+	alg      Algorithm
+	hash     crypto.Hash
+	key      []byte
+	hashPool *sync.Pool
 }
 
 func (h hsAlg) Algorithm() Algorithm {
@@ -76,7 +85,11 @@ func (h hsAlg) Verify(payload, signature []byte) error {
 }
 
 func (h hsAlg) sign(payload []byte) ([]byte, error) {
-	hasher := hmac.New(h.hash.New, h.key)
+	hasher := h.hashPool.Get().(hash.Hash)
+	defer func() {
+		hasher.Reset()
+		h.hashPool.Put(hasher)
+	}()
 
 	_, err := hasher.Write(payload)
 	if err != nil {

--- a/jwt_bench_test.go
+++ b/jwt_bench_test.go
@@ -1,0 +1,42 @@
+package jwt_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/cristalhq/jwt/v2"
+)
+
+func BenchmarkSignerHS(b *testing.B) {
+	b.StopTimer()
+
+	key := []byte("12345")
+	signer, signerErr := jwt.NewSignerHS(jwt.HS256, key)
+	if signerErr != nil {
+		b.Fatal(signerErr)
+	}
+	builder := jwt.NewBuilder(signer)
+
+	b.ReportAllocs()
+	b.StartTimer()
+
+	sink := uintptr(0)
+
+	for i := 0; i < b.N; i++ {
+		token, tokenErr := builder.Build(jwt.StandardClaims{
+			ID:       "id",
+			Issuer:   "sdf",
+			IssuedAt: jwt.NewNumericDate(time.Now()),
+		})
+		if tokenErr != nil {
+			b.Fatal(tokenErr)
+		}
+		sink += uintptr(unsafe.Pointer(token))
+	}
+
+	if rand.Intn(10000) > 9999 {
+		b.Log(sink)
+	}
+}


### PR DESCRIPTION
This is an experimental branch where we try to improve the performance of `hsAlg` hashers.

Current results:

```
name                 old time/op    new time/op    delta
HS/Sign-HS256-4        3.02µs ± 1%    2.80µs ± 5%   -7.30%  (p=0.000 n=10+10)
HS/Verify-HS256-4      1.53µs ± 2%    1.18µs ± 1%  -22.91%  (p=0.000 n=10+9)
HS/Sign-HS384-4        3.44µs ± 4%    2.81µs ± 4%  -18.39%  (p=0.000 n=10+9)
HS/Verify-HS384-4      1.81µs ± 1%    1.29µs ± 2%  -28.81%  (p=0.000 n=9+9)
HS/Sign-HS512-4        3.39µs ± 1%    2.87µs ± 4%  -15.24%  (p=0.000 n=9+10)
HS/Verify-HS512-4      1.86µs ± 5%    1.30µs ± 1%  -29.97%  (p=0.000 n=9+9)

name                 old alloc/op   new alloc/op   delta
HS/Sign-HS256-4        1.33kB ± 0%    0.85kB ± 0%  -36.14%  (p=0.000 n=10+10)
HS/Verify-HS256-4        512B ± 0%       32B ± 0%  -93.75%  (p=0.000 n=10+10)
HS/Sign-HS384-4        1.70kB ± 0%    0.90kB ± 0%  -47.17%  (p=0.000 n=10+10)
HS/Verify-HS384-4        848B ± 0%       48B ± 0%  -94.34%  (p=0.000 n=10+10)
HS/Sign-HS512-4        1.78kB ± 0%    0.98kB ± 0%  -45.05%  (p=0.000 n=10+10)
HS/Verify-HS512-4        864B ± 0%       64B ± 0%  -92.59%  (p=0.000 n=10+10)

name                 old allocs/op  new allocs/op  delta
HS/Sign-HS256-4          18.0 ± 0%      13.0 ± 0%  -27.78%  (p=0.000 n=10+10)
HS/Verify-HS256-4        6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=10+10)
HS/Sign-HS384-4          18.0 ± 0%      13.0 ± 0%  -27.78%  (p=0.000 n=10+10)
HS/Verify-HS384-4        6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=10+10)
HS/Sign-HS512-4          18.0 ± 0%      13.0 ± 0%  -27.78%  (p=0.000 n=10+10)
HS/Verify-HS512-4        6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=10+10)
```