### PR TITLE
Improve performance

### DIFF
--- a/algo.go
+++ b/algo.go
@@ -9,6 +9,7 @@ import (
 type Signer interface {
 	Algorithm() Algorithm
 	Sign(payload []byte) ([]byte, error)
+	SignatureSize() int
 }
 
 // Verifier is used to verify tokens.

--- a/algo_eddsa.go
+++ b/algo_eddsa.go
@@ -46,3 +46,7 @@ func (h edDSAAlg) Verify(payload, signature []byte) error {
 	}
 	return nil
 }
+
+func (h edDSAAlg) SignatureSize() int {
+	return ed25519.SignatureSize
+}

--- a/algo_es.go
+++ b/algo_es.go
@@ -100,6 +100,10 @@ func (h esAlg) Sign(payload []byte) ([]byte, error) {
 	return out, nil
 }
 
+func (h esAlg) SignatureSize() int {
+	return h.hash.Size()
+}
+
 func (h esAlg) Verify(payload, signature []byte) error {
 	if len(signature) != 2*h.keySize {
 		return ErrInvalidSignature

--- a/algo_hs.go
+++ b/algo_hs.go
@@ -64,6 +64,10 @@ func (h hsAlg) Sign(payload []byte) ([]byte, error) {
 	return h.sign(payload)
 }
 
+func (h hsAlg) SignatureSize() int {
+	return h.hash.Size()
+}
+
 func (h hsAlg) Verify(payload, signature []byte) error {
 	signed, err := h.sign(payload)
 	if err != nil {

--- a/algo_ps.go
+++ b/algo_ps.go
@@ -95,6 +95,10 @@ func (h psAlg) Sign(payload []byte) ([]byte, error) {
 	return signature, nil
 }
 
+func (h psAlg) SignatureSize() int {
+	return h.hash.Size()
+}
+
 func (h psAlg) Verify(payload, signature []byte) error {
 	signed, err := h.sign(payload)
 	if err != nil {

--- a/algo_rs.go
+++ b/algo_rs.go
@@ -75,6 +75,10 @@ func (h rsAlg) Sign(payload []byte) ([]byte, error) {
 	return signature, nil
 }
 
+func (h rsAlg) SignatureSize() int {
+	return h.hash.Size()
+}
+
 func (h rsAlg) Verify(payload, signature []byte) error {
 	signed, err := h.sign(payload)
 	if err != nil {

--- a/build_test.go
+++ b/build_test.go
@@ -150,6 +150,4 @@ func BenchmarkBuild(b *testing.B) {
 	}
 
 	_ = sink
-
-	b.Logf("%s %v", sink.raw, sink.signature)
 }

--- a/build_test.go
+++ b/build_test.go
@@ -118,3 +118,38 @@ func (badSigner) Sign(payload []byte) ([]byte, error) {
 func (badSigner) Verify(payload, signature []byte) error {
 	return errors.New("error by design")
 }
+
+func (badSigner) SignatureSize() int {
+	return 0
+}
+
+var sink *Token
+
+func BenchmarkBuild(b *testing.B) {
+	key := []byte("123456")
+	signer, _ := NewSignerHS(HS512, key)
+	builder := NewBuilder(signer)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var err error
+		sink, err = builder.Build(StandardClaims{
+			ID:        "long-id",
+			Audience:  nil,
+			Issuer:    "perf-test-run",
+			Subject:   "token",
+			ExpiresAt: nil,
+			IssuedAt:  nil,
+			NotBefore: nil,
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	_ = sink
+
+	b.Logf("%s %v", sink.raw, sink.signature)
+}


### PR DESCRIPTION
Несколько ухудшилась читаемость, однако получились такие результаты
```
name     old time/op    new time/op    delta
Build-8    2.06µs ± 1%    1.88µs ± 0%   -9.05%  (p=0.008 n=5+5)

name     old alloc/op   new alloc/op   delta
Build-8    1.78kB ± 0%    1.44kB ± 0%  -18.92%  (p=0.008 n=5+5)

name     old allocs/op  new allocs/op  delta
Build-8      15.0 ± 0%      11.0 ± 0%  -26.67%  (p=0.008 n=5+5)
```

Также добавлены методы для получения размера подписи.