### PR TITLE
add sync.Pool to get hash.Hash where possible

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,29 @@
+package jwt
+
+import (
+	"hash"
+	"sync"
+)
+
+type hashPool struct {
+	pool *sync.Pool
+}
+
+func newHashPool() *hashPool {
+	return &hashPool{
+		pool: &sync.Pool{},
+	}
+}
+
+func (p *hashPool) getHash(fn func() hash.Hash) hash.Hash {
+	h := p.pool.Get()
+	if h == nil {
+		return fn()
+	}
+	return h.(hash.Hash)
+}
+
+func (p *hashPool) putHash(h hash.Hash) {
+	h.Reset()
+	p.pool.Put(h)
+}


### PR DESCRIPTION
Similar to #44, just to make the same for all algorithms.

```
benchcmp bench.old bench.new
benchmark                        old ns/op     new ns/op     delta
BenchmarkEDSA/Sign-EdDSA-4       66128         66932         +1.22%
BenchmarkEDSA/Verify-EdDSA-4     170415        171653        +0.73%
BenchmarkES/Sign-ES256-4         35060         36800         +4.96%
BenchmarkES/Verify-ES256-4       95878         102948        +7.37%
BenchmarkES/Sign-ES384-4         5640494       5328269       -5.54%
BenchmarkES/Verify-ES384-4       14693353      11951887      -18.66%
BenchmarkES/Sign-ES512-4         11918140      9458677       -20.64%
BenchmarkES/Verify-ES512-4       27179389      20391382      -24.97%
BenchmarkPS/Sign-PS256-4         2079814       1979967       -4.80%
BenchmarkPS/Verify-PS256-4       110701        88832         -19.76%
BenchmarkPS/Sign-PS384-4         2741718       1868684       -31.84%
BenchmarkPS/Verify-PS384-4       161826        86363         -46.63%
BenchmarkPS/Sign-PS512-4         2559179       1869384       -26.95%
BenchmarkPS/Verify-PS512-4       95496         83714         -12.34%
BenchmarkRS/Sign-RS256-4         1864396       1860276       -0.22%
BenchmarkRS/Verify-RS256-4       84125         80451         -4.37%
BenchmarkRS/Sign-RS384-4         1884087       1909896       +1.37%
BenchmarkRS/Verify-RS384-4       80976         86621         +6.97%
BenchmarkRS/Sign-RS512-4         1867908       1894707       +1.43%
BenchmarkRS/Verify-RS512-4       80037         79639         -0.50%
BenchmarkHS/Sign-HS256-4         3322          2914          -12.28%
BenchmarkHS/Verify-HS256-4       1667          1299          -22.08%
BenchmarkHS/Sign-HS384-4         3724          2998          -19.50%
BenchmarkHS/Verify-HS384-4       1991          1410          -29.18%
BenchmarkHS/Sign-HS512-4         3884          3086          -20.55%
BenchmarkHS/Verify-HS512-4       2429          1435          -40.92%

benchmark                        old allocs     new allocs     delta
BenchmarkEDSA/Sign-EdDSA-4       18             18             +0.00%
BenchmarkEDSA/Verify-EdDSA-4     2              2              +0.00%
BenchmarkES/Sign-ES256-4         51             50             -1.96%
BenchmarkES/Verify-ES256-4       21             20             -4.76%
BenchmarkES/Sign-ES384-4         14474          14457          -0.12%
BenchmarkES/Verify-ES384-4       29655          32629          +10.03%
BenchmarkES/Sign-ES512-4         19591          19617          +0.13%
BenchmarkES/Verify-ES512-4       50897          37498          -26.33%
BenchmarkPS/Sign-PS256-4         129            128            -0.78%
BenchmarkPS/Verify-PS256-4       19             18             -5.26%
BenchmarkPS/Sign-PS384-4         129            128            -0.78%
BenchmarkPS/Verify-PS384-4       19             18             -5.26%
BenchmarkPS/Sign-PS512-4         129            128            -0.78%
BenchmarkPS/Verify-PS512-4       19             18             -5.26%
BenchmarkRS/Sign-RS256-4         123            122            -0.81%
BenchmarkRS/Verify-RS256-4       13             12             -7.69%
BenchmarkRS/Sign-RS384-4         123            122            -0.81%
BenchmarkRS/Verify-RS384-4       13             12             -7.69%
BenchmarkRS/Sign-RS512-4         123            122            -0.81%
BenchmarkRS/Verify-RS512-4       13             12             -7.69%
BenchmarkHS/Sign-HS256-4         18             13             -27.78%
BenchmarkHS/Verify-HS256-4       6              1              -83.33%
BenchmarkHS/Sign-HS384-4         18             13             -27.78%
BenchmarkHS/Verify-HS384-4       6              1              -83.33%
BenchmarkHS/Sign-HS512-4         18             13             -27.78%
BenchmarkHS/Verify-HS512-4       6              1              -83.33%

benchmark                        old bytes     new bytes     delta
BenchmarkEDSA/Sign-EdDSA-4       1424          1424          +0.00%
BenchmarkEDSA/Verify-EdDSA-4     293           295           +0.68%
BenchmarkES/Sign-ES256-4         3954          3826          -3.24%
BenchmarkES/Verify-ES256-4       1255          1131          -9.88%
BenchmarkES/Sign-ES384-4         1752088       1750090       -0.11%
BenchmarkES/Verify-ES384-4       3589214       3949067       +10.03%
BenchmarkES/Sign-ES512-4         3027917       3032247       +0.14%
BenchmarkES/Verify-ES512-4       7866515       5795388       -26.33%
BenchmarkPS/Sign-PS256-4         32892         32771         -0.37%
BenchmarkPS/Verify-PS256-4       5912          5762          -2.54%
BenchmarkPS/Sign-PS384-4         33097         32890         -0.63%
BenchmarkPS/Verify-PS384-4       6152          5909          -3.95%
BenchmarkPS/Sign-PS512-4         33125         32901         -0.68%
BenchmarkPS/Verify-PS512-4       6191          5949          -3.91%
BenchmarkRS/Sign-RS256-4         32247         32121         -0.39%
BenchmarkRS/Verify-RS256-4       5426          5297          -2.38%
BenchmarkRS/Sign-RS384-4         32355         32132         -0.69%
BenchmarkRS/Verify-RS384-4       5532          5311          -3.99%
BenchmarkRS/Sign-RS512-4         32370         32158         -0.65%
BenchmarkRS/Verify-RS512-4       5545          5329          -3.90%
BenchmarkHS/Sign-HS256-4         1328          848           -36.14%
BenchmarkHS/Verify-HS256-4       512           32            -93.75%
BenchmarkHS/Sign-HS384-4         1696          896           -47.17%
BenchmarkHS/Verify-HS384-4       848           48            -94.34%
BenchmarkHS/Sign-HS512-4         1776          976           -45.05%
BenchmarkHS/Verify-HS512-4       864           64            -92.59%
```