### PR TITLE
Add func to generate random 512 bits key

### DIFF
--- a/algo_hs.go
+++ b/algo_hs.go
@@ -3,9 +3,30 @@ package jwt
 import (
 	"crypto"
 	"crypto/hmac"
+	"crypto/rand"
 	"hash"
 	"sync"
 )
+
+func generateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Generates a key of random 512 bits
+func GenerateRandom512Bit() ([]byte, error) {
+	const byteSize = int(512.0 / 8)
+	key, err := generateRandomBytes(byteSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}
 
 // NewSignerHS returns a new HMAC-based signer.
 func NewSignerHS(alg Algorithm, key []byte) (*HSAlg, error) {

--- a/algo_hs_test.go
+++ b/algo_hs_test.go
@@ -43,13 +43,13 @@ func TestHS(t *testing.T) {
 func TestNewKey(t *testing.T) {
 	key, err := GenerateRandom512Bit()
 	if err != nil {
-		t.Fatalf(" %e", err)
+		t.Fatalf("Error returned directly from GenerateRandom512Bit: %e", err)
 	}
 
 	// 8 bits to 1 byte
 	const byteCount = int(512.0 / 8)
 	if l := len(key); l != byteCount {
-		t.Fatalf("Elength of key is %d, want %d", l, byteCount)
+		t.Fatalf("length of key is %d, want %d", l, byteCount)
 	}
 }
 

--- a/algo_hs_test.go
+++ b/algo_hs_test.go
@@ -40,6 +40,19 @@ func TestHS(t *testing.T) {
 	f(HS256, hsKey256, hsKeyAnother256, ErrInvalidSignature)
 }
 
+func TestNewKey(t *testing.T) {
+	key, err := GenerateRandom512Bit()
+	if err != nil {
+		t.Fatalf(" %e", err)
+	}
+
+	// 8 bits to 1 byte
+	const byteCount = int(512.0 / 8)
+	if l := len(key); l != byteCount {
+		t.Fatalf("Elength of key is %d, want %d", l, byteCount)
+	}
+}
+
 var (
 	hsKey256 = []byte("hmac-secret-key-256")
 	hsKey384 = []byte("hmac-secret-key-384")


### PR DESCRIPTION
Instead of showing people an insecure example, generate a key for them first

```go
// generate a key
key, err := GenerateRandom512Bit()
checkErr(err)

// create a Signer (HMAC in this example)
signer, err := jwt.NewSignerHS(jwt.HS256, key)
checkErr(err)

// create claims (you can create your own, see: Example_BuildUserClaims)
claims := &jwt.RegisteredClaims{
    Audience: []string{"admin"},
    ID:       "random-unique-string",
}

// create a Builder
builder := jwt.NewBuilder(signer)

// and build a Token
token, err := builder.Build(claims)
checkErr(err)

// here is token as a string
var _ string = token.String()
```